### PR TITLE
[feat] .pkl 파일 기반 데이터셋 생성 기능 추가

### DIFF
--- a/custom_dataset.py
+++ b/custom_dataset.py
@@ -1,12 +1,37 @@
 import json
+import os
 import os.path as osp
+import pickle
 
 import numpy as np
 import torch
+from dataset import *
 from PIL import Image
 from torch.utils.data import Dataset
 
-from dataset import *
+
+class PickledDataset(Dataset):
+    def __init__(self, data_dir, to_tensor=True):
+        self.data_dir = data_dir
+        self.data = os.listdir(data_dir)
+        self.to_tensor = to_tensor
+
+        self.data.sort()
+
+    def __getitem__(self, idx):
+        with open(file=self.data_dir + f"/{self.data[idx]}", mode="rb") as f:
+            image, score_map, geo_map, roi_mask = pickle.load(f)
+
+        if self.to_tensor:
+            image = torch.Tensor(image)
+            score_map = torch.Tensor(score_map)
+            geo_map = torch.Tensor(geo_map)
+            roi_mask = torch.Tensor(roi_mask)
+
+        return image, score_map, geo_map, roi_mask
+
+    def __len__(self):
+        return len(self.data)
 
 
 def valid_resize_img(img, vertices, size):

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -27,6 +27,8 @@ def parse_args():
 
 
 def pickle_dataset(dataset, type="train"):
+    os.makedirs(f"/opt/ml/input/data/medical/img/{type}_pickled", exist_ok=True)
+
     for img_num, data in tqdm(enumerate(iter(dataset)), total=len(dataset)):
         with open(file=f"/opt/ml/input/data/medical/img/{type}_pickled/{img_num}.pkl", mode="wb") as f:
             pickle.dump(data, f)

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -28,7 +28,7 @@ def parse_args():
 
 def pickle_dataset(dataset, type="train"):
     for img_num, data in tqdm(enumerate(iter(dataset)), total=len(dataset)):
-        with open(file=f"/opt/ml/input/data/medical/img/{type}_pickled1/{img_num}.pkl", mode="wb") as f:
+        with open(file=f"/opt/ml/input/data/medical/img/{type}_pickled/{img_num}.pkl", mode="wb") as f:
             pickle.dump(data, f)
 
 

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -1,0 +1,42 @@
+import os
+import pickle
+from argparse import ArgumentParser
+
+from dataset import SceneTextDataset
+from east_dataset import EASTDataset
+from tqdm import tqdm
+
+
+def parse_args():
+    parser = ArgumentParser()
+
+    # Conventional args
+    parser.add_argument("--data_dir", type=str, default=os.environ.get("SM_CHANNEL_TRAIN", "../data/medical"))
+    parser.add_argument("--num_workers", type=int, default=6)
+    parser.add_argument("--image_size", type=int, default=2048)
+    parser.add_argument("--input_size", type=int, default=1024)
+    parser.add_argument("--batch_size", type=int, default=8)
+    parser.add_argument("--ignore_tags", type=list, default=["masked", "excluded-region", "maintable", "stamp"])
+
+    args = parser.parse_args()
+
+    if args.input_size % 32 != 0:
+        raise ValueError("`input_size` must be a multiple of 32")
+
+    return args
+
+
+def pickle_dataset(dataset, type="train"):
+    for img_num, data in tqdm(enumerate(iter(dataset)), total=len(dataset)):
+        with open(file=f"/opt/ml/input/data/medical/img/{type}_pickled1/{img_num}.pkl", mode="wb") as f:
+            pickle.dump(data, f)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    train_dataset = SceneTextDataset(
+        args.data_dir, split="train", image_size=args.image_size, crop_size=args.input_size, ignore_tags=args.ignore_tags
+    )
+    train_dataset = EASTDataset(train_dataset)
+    pickle_dataset(train_dataset, type='train')


### PR DESCRIPTION
## Overview
- pickle 라이브러리를 활용해서 .pkl 파일 기반 데이터셋 생성 기능 구현

## Change log
- [preprocessing.py] 이미지 전처리 결과를 .pkl 파일로 저장해주는 함수 `pickle_dataset()` 구현
- [custom_dataset.py] .pkl 파일을 기반으로 데이터셋을 생성하는 클래스 `PickleDataset` 구현

## To Reviewer
- .pkl 파일은 `python preprocessing.py` 명령어를 실행해서 생성합니다.
- .pkl 파일은 `/opt/ml/input/data/medical/img/{type}_pickled` 디렉토리 아래에 저장됩니다.
    - `{type}`은 함수 `pickle_dataset()`의 인자값로서 전처리 대상인 이미지가 속한 데이터셋의 유형(e.g., train, validation, test, etc.)를 뜻합니다.